### PR TITLE
Rework timeout implementation to panic when the timer is dropped.

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -5,7 +5,6 @@
 
 use std::fmt;
 use std::future::Future;
-use std::io;
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -154,19 +153,16 @@ pub fn fires_at(timeout: &Delay) -> Instant {
 }
 
 impl Future for Delay {
-    type Output = io::Result<()>;
+    type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let state = match self.state {
             Some(ref state) => state,
-            None => {
-                let err = Err(io::Error::new(io::ErrorKind::Other, "timer has gone away"));
-                return Poll::Ready(err);
-            }
+            None => panic!("timer has gone away"),
         };
 
         if state.state.load(SeqCst) & 1 != 0 {
-            return Poll::Ready(Ok(()));
+            return Poll::Ready(());
         }
 
         state.waker.register(&cx.waker());
@@ -175,11 +171,8 @@ impl Future for Delay {
         // state. If we've fired the first bit is set, and if we've been
         // invalidated the second bit is set.
         match state.state.load(SeqCst) {
-            n if n & 0b01 != 0 => Poll::Ready(Ok(())),
-            n if n & 0b10 != 0 => Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::Other,
-                "timer has gone away",
-            ))),
+            n if n & 0b01 != 0 => Poll::Ready(()),
+            n if n & 0b10 != 0 => panic!("timer has gone away"),
             _ => Poll::Pending,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ mod global;
 mod heap;
 
 pub mod ext;
-pub use ext::{TryFutureExt, TryStreamExt};
+pub use ext::{FutureExt, StreamExt, TimedOut};
 
 /// A "timer heap" used to power separately owned instances of `Delay` and
 /// `Interval`.

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 use futures::future::poll_fn;
 use futures_timer::{Delay, Timer};
 
-use std::error::Error;
 use std::pin::Pin;
 use std::task::Poll;
 
@@ -17,48 +16,48 @@ fn far_future() -> Instant {
 async fn works() {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
-    let _d = Delay::new(dur).await;
+    Delay::new(dur).await;
     assert!(i.elapsed() > dur);
 }
 
 #[runtime::test]
+#[should_panic]
 async fn error_after_inert() {
     let t = Timer::new();
     let handle = t.handle();
     drop(t);
-    let res = Delay::new_handle(far_future(), handle).await;
-    assert!(res.is_err());
+    Delay::new_handle(far_future(), handle).await;
 }
 
 #[runtime::test]
+#[should_panic]
 async fn drop_makes_inert() {
     let t = Timer::new();
     let handle = t.handle();
     let timeout = Delay::new_handle(far_future(), handle);
     drop(t);
-    let res = timeout.await;
-    assert!(res.is_err());
+    timeout.await;
 }
 
 #[runtime::test]
-async fn reset() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+async fn reset() {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
     let mut d = Delay::new(dur);
 
     // Allow us to re-use a future
-    Pin::new(&mut d).await?;
+    Pin::new(&mut d).await;
 
     assert!(i.elapsed() > dur);
 
     let i = Instant::now();
     d.reset(dur);
-    d.await?;
+    d.await;
     assert!(i.elapsed() > dur);
-    Ok(())
 }
 
 #[runtime::test]
+#[should_panic]
 async fn drop_timer_wakes() {
     let t = Timer::new();
     let handle = t.handle();
@@ -66,7 +65,7 @@ async fn drop_timer_wakes() {
     let mut t = Some(t);
     let f = poll_fn(move |cx| {
         let timeout = unsafe { Pin::new_unchecked(&mut timeout) };
-        match TryFuture::try_poll(timeout, cx) {
+        match Future::poll(timeout, cx) {
             Poll::Pending => {}
             other => return other,
         }
@@ -74,6 +73,5 @@ async fn drop_timer_wakes() {
         Poll::Pending
     });
 
-    let res = f.await;
-    assert_eq!("timer has gone away", res.unwrap_err().description());
+    f.await;
 }

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,21 +1,18 @@
-use std::error::Error;
 use std::time::{Duration, Instant};
 
 use futures_timer::Delay;
 
 #[runtime::test]
-async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+async fn smoke() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
-    Delay::new(dur).await?;
+    Delay::new(dur).await;
     assert!(start.elapsed() >= (dur / 2));
-    Ok(())
 }
 
 #[runtime::test]
-async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+async fn two() {
     let dur = Duration::from_millis(10);
-    Delay::new(dur).await?;
-    Delay::new(dur).await?;
-    Ok(())
+    Delay::new(dur).await;
+    Delay::new(dur).await;
 }


### PR DESCRIPTION
This also changes the extension traits to extend Future/Stream instead of TryFuture/TryStream.

Follows up on review of #22 (sorry about the delay!)

For now I've left this as a draft because I've set the Output/Item in the extension traits to an `Option`. @yoshuawuyts I'd be interested on your thoughts as to whether we want this to be:

* `Option` as is.
* `io::Error` as in runtime.
* Another custom error.
* Something else.

I don't love `Option` here, especially with the nested option in the stream extension. I think something like

```rust
struct TimeoutError(());
```

might work quite well instead of `io::Error`.

---

## Description

This reworks the timer implementation to panic on error instead of returning an `io::Error`.

## Motivation and Context

This simplifies the extension traits and removes the `From<io::Error>` trait bound from #21.

## How Has This Been Tested?

Tests reworked/pass.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)