### PR TITLE
Removing need to use Mutex on `ScheduledTimer`'s slot field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,48 @@
 ### Stats
 ```diff
  .travis.yml       |   4 +-
+ CHANGELOG.md      |  81 +---------------------------------
+ Cargo.toml        |   9 +----
+ README.md         |  29 +++++++-----
+ src/arc_list.rs   |  16 +++----
+ src/delay.rs      |  72 +++++++++---------------------
+ src/ext.rs        | 133 +++++++++++++++++++------------------------------------
+ src/global.rs     |  56 ++++++-----------------
+ src/heap.rs       |  56 +++++++++--------------
+ src/interval.rs   |  87 ++++++++++++++----------------------
+ src/lib.rs        |  90 ++++++++++++++++---------------------
+ tests/ext.rs      | 107 +--------------------------------------------
+ tests/interval.rs |  22 ++++-----
+ tests/smoke.rs    |  64 ++++++++++----------------
+ tests/timeout.rs  |  26 +++++------
+ 15 files changed, 263 insertions(+), 589 deletions(-)
+```
+
+
+## 2018-02-07, Version 0.1.1
+### Commits
+- [[`4637e672f8`](https://github.com/alexcrichton/futures-timer/commit/4637e672f8748c6ee41ebc93a1a97e118ef8b855)] Bump to 0.1.1 (Alex Crichton)
+- [[`0cf3dab722`](https://github.com/alexcrichton/futures-timer/commit/0cf3dab722860b5623cc835d10a1f78d953c63d9)] Add extension traits for convenience methods (Alex Crichton)
+- [[`56c46fe881`](https://github.com/alexcrichton/futures-timer/commit/56c46fe8812cde701dd983d843c8f92189b2f911)] Beef up the README slightly (Alex Crichton)
+- [[`dfd80e2e2b`](https://github.com/alexcrichton/futures-timer/commit/dfd80e2e2b011bc0a790d88f8219fc838e02b608)] Various updates: (Alex Crichton)
+- [[`2f8e18cc71`](https://github.com/alexcrichton/futures-timer/commit/2f8e18cc718a3bc57cabcbbeaf79cbead0bb47f0)] Rename `Sleep` to `Delay` (Alex Crichton)
+- [[`9715aa6417`](https://github.com/alexcrichton/futures-timer/commit/9715aa64176ef006a4bcda05dc8188160476a2d6)] Clarify wording of license information in README. (Alex Crichton)
+- [[`38e14656d7`](https://github.com/alexcrichton/futures-timer/commit/38e14656d76cb9478eaea0c54b1de117bacd63ee)] Rename Timeout to Sleep (Alex Crichton)
+- [[`9e58f3a330`](https://github.com/alexcrichton/futures-timer/commit/9e58f3a3307422042b93787cb18d93cf6c6d6671)] Import some tokio-core tests (Alex Crichton)
+- [[`9c4a3958cd`](https://github.com/alexcrichton/futures-timer/commit/9c4a3958cde60156941415bb806db05d21ca3f1b)] Correct take_and_seal implementation (Alex Crichton)
+- [[`56dddd9d57`](https://github.com/alexcrichton/futures-timer/commit/56dddd9d5716ed6cef8841f70c3be6d1536f2dac)] Fix some races with invalidating timeouts (Alex Crichton)
+- [[`1653e6c789`](https://github.com/alexcrichton/futures-timer/commit/1653e6c7896348ec928c71dd272cecd8b26ec951)] typo (Alex Crichton)
+- [[`e18b12069b`](https://github.com/alexcrichton/futures-timer/commit/e18b12069b50a02a217aa86945e5b68ac89e1459)] Add a doc link (Alex Crichton)
+- [[`c3d239e874`](https://github.com/alexcrichton/futures-timer/commit/c3d239e8740a217a3a352ad3538e4bd694794097)] Add various metadata (Alex Crichton)
+- [[`57324b99d4`](https://github.com/alexcrichton/futures-timer/commit/57324b99d4b2906bda548514b2bf238c7f83aee6)] Add Travis config (Alex Crichton)
+- [[`4acd39db09`](https://github.com/alexcrichton/futures-timer/commit/4acd39db096d97c5f9d60380194b9680a402ebf7)] Make `fires_at` private (Alex Crichton)
+- [[`7b3f3b05f0`](https://github.com/alexcrichton/futures-timer/commit/7b3f3b05f0c2edc8f502fb22f406dc9c11d55da8)] Add Interval (Alex Crichton)
+- [[`6b65dd457a`](https://github.com/alexcrichton/futures-timer/commit/6b65dd457a9d8f1e9b78cb3d0e57e74ed8bb10be)] Fix reset (Alex Crichton)
+- [[`2603432e78`](https://github.com/alexcrichton/futures-timer/commit/2603432e78322c4f272509b3e938d7a58194d023)] Initial commit (Alex Crichton)
+
+### Stats
+```diff
+ .travis.yml       |   4 +-
  CHANGELOG.md      |  40 +----------------
  Cargo.toml        |   9 +----
  README.md         |  29 +++++++-----

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,8 @@ futures-preview = "0.3.0-alpha.16"
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-runtime = "0.3.0-alpha.4"
+runtime = "0.3.0-alpha.6"
+
+[patch.crates-io.runtime]
+git = "https://github.com/rustasync/runtime"
+rev = "6177e6ead4f1a5fd23640db5d931d85b2dd55c5d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,3 @@ pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
 runtime = "0.3.0-alpha.7"
-
-[patch.crates-io.runtime]
-git = "https://github.com/rustasync/runtime"
-rev = "6177e6ead4f1a5fd23640db5d931d85b2dd55c5d

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -70,7 +70,7 @@ impl Delay {
             state: AtomicUsize::new(0),
             waker: AtomicWaker::new(),
             inner: handle.inner,
-            slot: AtomicUsize::new(0), //AtomicPtr::new(ptr::null_mut()), //Mutex::new(None),
+            slot: AtomicUsize::new(0),
         }));
 
         // If we fail to actually push our node then we've become an inert

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -7,7 +7,8 @@ use std::fmt;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::sync::atomic::AtomicUsize;
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, AtomicPtr};
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -64,12 +65,13 @@ impl Delay {
                 }
             }
         };
+
         let state = Arc::new(Node::new(ScheduledTimer {
             at: Mutex::new(Some(at)),
             state: AtomicUsize::new(0),
             waker: AtomicWaker::new(),
             inner: handle.inner,
-            slot: Mutex::new(None),
+            slot: AtomicPtr::new(ptr::null_mut()), //Mutex::new(None),
         }));
 
         // If we fail to actually push our node then we've become an inert

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -7,8 +7,7 @@ use std::fmt;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::ptr;
-use std::sync::atomic::{AtomicUsize, AtomicPtr};
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -71,7 +70,7 @@ impl Delay {
             state: AtomicUsize::new(0),
             waker: AtomicWaker::new(),
             inner: handle.inner,
-            slot: AtomicPtr::new(ptr::null_mut()), //Mutex::new(None),
+            slot: AtomicUsize::new(0), //AtomicPtr::new(ptr::null_mut()), //Mutex::new(None),
         }));
 
         // If we fail to actually push our node then we've become an inert

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -89,7 +89,7 @@ impl<T: Ord> Heap<T> {
 
     pub fn pop(&mut self) -> Option<T> {
         self.assert_consistent();
-      
+
         if self.items.is_empty() {
             return None;
         }
@@ -129,7 +129,7 @@ impl<T: Ord> Heap<T> {
         }
 
         self.assert_consistent();
-      
+
         item
     }
 
@@ -145,7 +145,7 @@ impl<T: Ord> Heap<T> {
             set_index(&mut self.index, b[0].1, idx);
             idx = parent;
         }
-      
+
         idx
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,8 @@ impl Timer {
     /// the timer's `poll` call, where the `at` field is locked for exclusive access to the
     /// `node`. Hence we're actually running synchronized code on `node`.
     fn update_or_add(&mut self, at: Instant, node: Arc<Node<ScheduledTimer>>) {
-        /// TODO: Avoid remove + push and instead just do one sift of the heap?  In theory we could
-        /// update it in place and then do the percolation as necessary
+        // TODO: Avoid remove + push and instead just do one sift of the heap?  In theory we could
+        // update it in place and then do the percolation as necessary
 
         // If this slot's `idx` is still around and it still points a registered timer,
         // then we jettison it form the timer heap.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl Timer {
     /// the timer's `poll` call, where the `at` field is locked for exclusive access to the
     /// `node`. Hence we're actually running synchronized code on `node`.
     fn update_or_add(&mut self, at: Instant, node: Arc<Node<ScheduledTimer>>) {
-        ///TODO: Avoid remove + push and instead just do one sift of the heap?  In theory we could
+        /// TODO: Avoid remove + push and instead just do one sift of the heap?  In theory we could
         /// update it in place and then do the percolation as necessary
 
         // If this slot's `idx` is still around and it still points a registered timer,
@@ -289,7 +289,7 @@ impl Future for Timer {
         while let Some(node) = list.pop() {
             // Note: both `update_or_add` and `remove` are only accessed in this scope and hence,
             //       thread-safe if node is pre-locked (no one else could have access to the
-            //       underlying data.
+            //       underlying data).
 
             let at = *node.at.lock().unwrap();
 


### PR DESCRIPTION
Removing the need to use Mutex on on `ScheduledTimer`'s slot field

## Description
After analyzing the usage of `ScheduledTimer`'s slot field in the library, it is determined that it is possible to remove Mutex protection from `ScheduledTimer`'s slot field, and replace it with a more 
generic and light-weight `AtomicUsize` struct.

A few code changes are made to accommodate the removal of the lock code and using its replacement of the atomic structure. 

## Motivation and Context
It has been documented as a `TODO` in the library source code that use `Mutex` for the `slot` field is probably an overkill and we should be able to explore an alternative solution for the same purpose. After investigations, it's clear that such goal is achievable, since modifying a `ScheduleTimer` instance almost always involves acquiring a `Mutex` lock for the `at` field, that effectively fend off all concurrent access or modifications on the instance, hence guarantee the thread safety.

In specific, all code that access or update the `slot` field are either called from timer's `poll` method, or from the reset code (i.e. from `Timer`'s `advance_to` method). The former's thread-safety is guaranteed the by locking the entire `node` via the `at`-field's lock structure, hence the `update_or_add` and `remove` call are essentially synchronized code; the later is a bit complex, though the intention is to clean up the `slot`, field, because the index location it points to has already been vacated from the previous `pop` call, hence we shall simply reset the slot index to 0 at this point. 

## How Has This Been Tested?
- Integrated test and unit tests have been run.
- End to end tests on timeout-related features have been tested as well.

## Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [    ] New feature (non-breaking change which adds functionality)
- [    ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [  ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [  ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes (existing tests already cover all the affected code area).
- [X] All new and existing tests passed.
