### PR TITLE
Remove error from poll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-timer"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,6 @@ mod timer;
 use arc_list::{ArcList, Node};
 use heap::{Heap, Slot};
 use heap_timer::HeapTimer;
-use timer::{ScheduledTimer, TimerHandle};
-
-#[doc(hidden)]
-pub use timer::Timer;
+use timer::{ScheduledTimer, Timer, TimerHandle};
 
 pub use self::delay::Delay;

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -7,7 +7,7 @@ use futures_timer::Delay;
 async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
-    Delay::new(dur).await?;
+    Delay::new(dur).await;
     assert!(start.elapsed() >= (dur / 2));
     Ok(())
 }
@@ -15,7 +15,7 @@ async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 #[runtime::test]
 async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
-    Delay::new(dur).await?;
-    Delay::new(dur).await?;
+    Delay::new(dur).await;
+    Delay::new(dur).await;
     Ok(())
 }


### PR DESCRIPTION
Assumes the timer is always global (which is accurate after #36), making it so `Delay` no longer returns `Result`. Closes #14. Thanks!