### PR TITLE
prep 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-timer"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Prepares the 2.0 release of this crate, updating us to the latest futures. 2.0 is because this is a new trait in our public bounds that's incompatible with prior versions. Thanks!