### PR TITLE
remove futures-core dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures-core = "0.3.1"
 
 [dev-dependencies]
 async-std = { version = "1.0.1", features = ["attributes"] }

--- a/src/atomic_waker.rs
+++ b/src/atomic_waker.rs
@@ -74,11 +74,13 @@ impl AtomicWaker {
     /// Here is how `register` is used when implementing a flag.
     ///
     /// ```
-    /// use futures::future::Future;
-    /// use futures::task::{Context, Poll, AtomicWaker};
+    /// use std::future::Future;
+    /// use std::task::{Context, Poll};
     /// use std::sync::atomic::AtomicBool;
     /// use std::sync::atomic::Ordering::SeqCst;
     /// use std::pin::Pin;
+    ///
+    /// use futures::task::AtomicWaker;
     ///
     /// struct Flag {
     ///     waker: AtomicWaker,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! # async fn main() {
 //! use std::time::Duration;
 //! use futures_timer::Delay;
-//! use futures::prelude::*;
 //!
 //! let now = Delay::new(Duration::from_secs(3)).await;
 //! println!("waited for 3 secs");

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
-use futures_core::future::Future;
+use std::future::Future;
 
 use crate::AtomicWaker;
 use crate::{global, ArcList, Heap, HeapTimer, Node, Slot};


### PR DESCRIPTION
Removes `futures-core` dep as per #43. I indeed missed we were not using any `futures-core` types that aren't already part of std anymore, so this gives us a chance to remove unused deps. Thanks!