### PR TITLE
migrate from runtime to async-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures-core = "0.3.0"
+futures-core = "0.3.1"
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-futures = "0.3.0"
-runtime = "0.3.0-alpha.8"
+async-std = { version = "1.0.1", features = ["attributes"] }
+futures = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```no_run
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() {
 //! use std::time::Duration;
 //! use futures_timer::Delay;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
-use async_std;
 use futures_timer::Delay;
 
 #[async_std::test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2,9 +2,10 @@ use std::error::Error;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
+use async_std;
 use futures_timer::Delay;
 
-#[runtime::test]
+#[async_std::test]
 async fn works() {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
@@ -12,7 +13,7 @@ async fn works() {
     assert!(i.elapsed() > dur);
 }
 
-#[runtime::test]
+#[async_std::test]
 async fn reset() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let i = Instant::now();
     let dur = Duration::from_millis(100);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::time::{Duration, Instant};
 
-use async_std;
 use futures_timer::Delay;
 
 #[async_std::test]

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,9 +1,10 @@
 use std::error::Error;
 use std::time::{Duration, Instant};
 
+use async_std;
 use futures_timer::Delay;
 
-#[runtime::test]
+#[async_std::test]
 async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
@@ -12,7 +13,7 @@ async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Ok(())
 }
 
-#[runtime::test]
+#[async_std::test]
 async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     Delay::new(dur).await;


### PR DESCRIPTION
Given that the runtime crate is no longer maintained I thought it might be good to migrate this.