### PR TITLE
Remove an unused `use` declaration in doctest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! # async fn main() {
 //! use std::time::Duration;
 //! use futures_timer::Delay;
-//! use futures::executor::block_on;
 //!
 //! let now = Delay::new(Duration::from_secs(3)).await;
 //! println!("waited for 3 secs");


### PR DESCRIPTION
The declaration became unused in commit aa7d2bcd2d3936236e96ac3d94de139b1f1ca898.