### PR TITLE
Fix panic when `Delay` is used after `Poll::Ready`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,26 @@ jobs:
       - name: cargo doc
         run: cargo doc --no-deps
 
+  test_wasm:
+    name: Test (wasm)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust and add wasm target
+        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }} && rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: wasm-pack@0.12.1
+      - name: cargo test
+        run: wasm-pack test --firefox --headless -- --features=wasm-bindgen
+      - name: cargo doc
+        run: cargo doc --no-deps --target=wasm32-unknown-unknown --features=wasm-bindgen
+
   style:
     name: Style
     runs-on: ubuntu-latest
@@ -59,14 +79,3 @@ jobs:
           git -c user.name='ci' -c user.email='ci' commit -m 'Deploy futures-timer API documentation'
           git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/master' && github.repository == 'async-rs/futures-timer'
-
-  check_wasm:
-    name: Check Wasm
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Install Rust and add wasm target
-        run: rustup update stable && rustup target add wasm32-unknown-unknown
-      - name: cargo check
-        run: cargo check --target wasm32-unknown-unknown --features wasm-bindgen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ send_wrapper = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.0.1", features = ["attributes"] }
+cfg-if = "1.0.0"
 futures = "0.3.1"
+wasm-bindgen-test = "0.3.42"
+web-time = "1.1.0"
 
 [features]
 wasm-bindgen = [

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,10 +1,22 @@
 use std::error::Error;
 use std::pin::Pin;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use futures::FutureExt;
 use futures_timer::Delay;
 
-#[async_std::test]
+cfg_if::cfg_if! {
+    if #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))] {
+        use wasm_bindgen_test::wasm_bindgen_test as async_test;
+        use web_time::Instant;
+        wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    } else {
+        use std::time::Instant;
+        use async_std::test as async_test;
+    }
+}
+
+#[async_test]
 async fn works() {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
@@ -12,7 +24,7 @@ async fn works() {
     assert!(i.elapsed() > dur);
 }
 
-#[async_std::test]
+#[async_test]
 async fn reset() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
@@ -28,4 +40,16 @@ async fn reset() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     d.await;
     assert!(i.elapsed() > dur);
     Ok(())
+}
+
+#[async_test]
+async fn use_after_ready() {
+    let dur = Duration::from_millis(100);
+    let mut d = Delay::new(dur);
+
+    Pin::new(&mut d).await;
+
+    // Use after ready should return immediately if `Delay::reset`
+    // was not called.
+    Pin::new(&mut d).now_or_never().unwrap();
 }

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,9 +1,20 @@
 use std::error::Error;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures_timer::Delay;
 
-#[async_std::test]
+cfg_if::cfg_if! {
+    if #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))] {
+        use wasm_bindgen_test::wasm_bindgen_test as async_test;
+        use web_time::Instant;
+        wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    } else {
+        use std::time::Instant;
+        use async_std::test as async_test;
+    }
+}
+
+#[async_test]
 async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
@@ -12,7 +23,7 @@ async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Ok(())
 }
 
-#[async_std::test]
+#[async_test]
 async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     Delay::new(dur).await;


### PR DESCRIPTION
WASM implementation was inconsistent to the native once when `Delay` was polled after it returned `Poll::Ready`. WASM was producing a panic because [`gloo_timers::future::TimeoutFuture`](https://docs.rs/gloo-timers/0.3.0/gloo_timers/future/struct.TimeoutFuture.html) panic in this case.

In this PR I also enable test cases under `tests` to run in WASM.

We discovered this bug while researching https://github.com/eigerco/lumina/issues/256.