### PR TITLE
cfg-gate wasm dependencies for wasm32` targets and update gloo-timers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = """
 Timeouts for futures.
 """
 
-[dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.2.0", features = ["futures"], optional = true }
 send_wrapper = { version = "0.4.0", optional = true }
 


### PR DESCRIPTION
The `gloo-timers` and `send_wrapper` dependencies are used only on `cfg(target_arch = "wasm32")`; make sure they are not compiled outside of that `cfg` even if the `wasm-bindgen` feature is enabled.