### PR TITLE
fix: address compilation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ wasm-bindgen = [
     "gloo-timers",
     "send_wrapper"
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(assert_timer_heap_consistent)'] }

--- a/src/native/atomic_waker.rs
+++ b/src/native/atomic_waker.rs
@@ -41,10 +41,6 @@ const WAKING: usize = 0b10;
 impl AtomicWaker {
     /// Create an `AtomicWaker`.
     pub fn new() -> AtomicWaker {
-        // Make sure that task is Sync
-        trait AssertSync: Sync {}
-        impl AssertSync for Waker {}
-
         AtomicWaker {
             state: AtomicUsize::new(WAITING),
             waker: UnsafeCell::new(None),
@@ -104,8 +100,11 @@ impl AtomicWaker {
     /// }
     /// ```
     pub fn register(&self, waker: &Waker) {
-        match self.state.compare_and_swap(WAITING, REGISTERING, Acquire) {
-            WAITING => {
+        match self
+            .state
+            .compare_exchange(WAITING, REGISTERING, Acquire, Acquire)
+        {
+            Ok(_) => {
                 unsafe {
                     // Locked acquired, update the waker cell
                     *self.waker.get() = Some(waker.clone());
@@ -144,13 +143,13 @@ impl AtomicWaker {
                     }
                 }
             }
-            WAKING => {
+            Err(WAKING) => {
                 // Currently in the process of waking the task, i.e.,
                 // `wake` is currently being called on the old task handle.
                 // So, we call wake on the new waker
                 waker.wake_by_ref();
             }
-            state => {
+            Err(state) => {
                 // In this case, a concurrent thread is holding the
                 // "registering" lock. This probably indicates a bug in the
                 // caller's code as racing to call `register` doesn't make much


### PR DESCRIPTION
- Extend custom cfg's with `assert_timer_heap_consistent`, required after [Rust 1.80's introduction of `unexpected_cfgs` lint](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/#checked-cfg-names-and-values)
- Remove no longer required `AssertSync` trait and impl for `Waker` `Waker`'s `Sync` impl has been stable [since Rust 1.36](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0/#library-changes)
-  Replace  [`compare_and_swap`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.compare_and_swap) deprecated since Rust 1.50 with [`compare_exchange` ](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange)