### PR TITLE
fix: mark raw waker callbacks unsafe

### DIFF
--- a/src/native/global.rs
+++ b/src/native/global.rs
@@ -82,21 +82,21 @@ fn run(mut timer: Timer, done: Arc<AtomicBool>) {
 
 static VTABLE: RawWakerVTable = RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
 
-fn raw_clone(ptr: *const ()) -> RawWaker {
+unsafe fn raw_clone(ptr: *const ()) -> RawWaker {
     let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr as *const Thread) });
     mem::forget(me.clone());
     RawWaker::new(ptr, &VTABLE)
 }
 
-fn raw_wake(ptr: *const ()) {
+unsafe fn raw_wake(ptr: *const ()) {
     unsafe { Arc::from_raw(ptr as *const Thread) }.unpark()
 }
 
-fn raw_wake_by_ref(ptr: *const ()) {
+unsafe fn raw_wake_by_ref(ptr: *const ()) {
     ManuallyDrop::new(unsafe { Arc::from_raw(ptr as *const Thread) }).unpark()
 }
 
-fn raw_drop(ptr: *const ()) {
+unsafe fn raw_drop(ptr: *const ()) {
     unsafe { Arc::from_raw(ptr as *const Thread) };
 }
 


### PR DESCRIPTION
Fixes #80.

Hi, thanks for maintaining this crate.

The RawWaker callbacks reconstruct an `Arc<Thread>` from the raw pointer passed by the waker vtable. This is only valid when the pointer was originally produced by `Arc::<Thread>::into_raw` and follows the ownership rules required by the `RawWakerVTable`.

Previously these callback functions were plain safe functions, even though calling them directly with an arbitrary pointer could cause undefined behavior. This PR marks the callbacks as `unsafe fn`. The actual runtime behavior is unchanged.