### PR TITLE
Add wasm32-wasip2 backend using wasi:clocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ Timeouts for futures.
 gloo-timers = { version = "0.4.0", features = ["futures"], optional = true }
 send_wrapper = { version = "0.6.0", optional = true }
 
+# WASI Preview 2 backend: a `wasi:clocks` timer driven by the `wstd` reactor.
+# Pulled in only for `wasm32-wasip2`, where the default thread-based backend
+# cannot run (the component model is single-threaded).
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))'.dependencies]
+wstd = "0.6"
+wasip2 = "1.0"
+
 [dev-dependencies]
 async-std = { version = "1.13", features = ["attributes"] }
 futures = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,37 @@
 #![deny(missing_docs)]
 #![warn(missing_debug_implementations)]
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-bindgen")))]
-mod native;
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
-mod wasm;
+// On `wasm32-wasip2` the thread-based `native` backend cannot run (the WASI
+// component model is single-threaded), so use a `wasi:clocks`-backed timer.
+// `target_env = "p2"` selects WASI Preview 2 specifically, leaving `wasip1`
+// (and any future preview) on the `native` backend.
+#[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))]
+mod wasip2;
+#[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))]
+pub use self::wasip2::Delay;
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-bindgen")))]
-pub use self::native::Delay;
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+// Browser wasm with the `wasm-bindgen` feature: `setTimeout` via gloo-timers.
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasm-bindgen",
+    not(all(target_os = "wasi", target_env = "p2"))
+))]
+mod wasm;
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasm-bindgen",
+    not(all(target_os = "wasi", target_env = "p2"))
+))]
 pub use self::wasm::Delay;
+
+// All other targets: the thread-backed timer wheel.
+#[cfg(not(any(
+    all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"),
+    all(target_arch = "wasm32", feature = "wasm-bindgen")
+)))]
+mod native;
+#[cfg(not(any(
+    all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"),
+    all(target_arch = "wasm32", feature = "wasm-bindgen")
+)))]
+pub use self::native::Delay;

--- a/src/wasip2.rs
+++ b/src/wasip2.rs
@@ -1,0 +1,66 @@
+//! A version of `Delay` that works on `wasm32-wasip2`.
+//!
+//! The default `native` backend relies on a background timer thread, which the
+//! WASI Preview 2 component model cannot spawn (it is single-threaded). This
+//! backend instead arms a `wasi:clocks/monotonic-clock` timer and awaits the
+//! resulting pollable through the [`wstd`] reactor, so it integrates with any
+//! executor built on `wstd::runtime` (e.g. `#[wstd::main]` / `wstd::runtime::block_on`).
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use wstd::runtime::{AsyncPollable, WaitFor};
+
+/// A future which will fire at `dur` time into the future, backed by
+/// `wasi:clocks/monotonic-clock` and driven by the `wstd` reactor.
+pub struct Delay {
+    wait_for: WaitFor,
+}
+
+// SAFETY: `wasm32-wasip2` is single-threaded; the underlying WASI pollable
+// handle is a plain integer that is trivially safe to move across the
+// non-existent thread boundary. `Delay` must be `Send + Sync` to match the
+// other backends' API.
+unsafe impl Send for Delay {}
+unsafe impl Sync for Delay {}
+
+impl Delay {
+    /// Creates a new future which will fire at `dur` time into the future.
+    ///
+    /// Must be polled from within a `wstd::runtime` executor context.
+    pub fn new(dur: Duration) -> Delay {
+        Delay {
+            wait_for: arm(dur),
+        }
+    }
+
+    /// Resets the timeout to fire `dur` time into the future.
+    pub fn reset(&mut self, dur: Duration) {
+        self.wait_for = arm(dur);
+    }
+}
+
+/// Arm a monotonic-clock timer for `dur` and wrap it as an awaitable pollable.
+fn arm(dur: Duration) -> WaitFor {
+    let ns = dur.as_nanos().min(u64::MAX as u128) as u64;
+    let pollable = wasip2::clocks::monotonic_clock::subscribe_duration(ns);
+    AsyncPollable::new(pollable).wait_for()
+}
+
+impl Future for Delay {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // `WaitFor` is `Unpin`, so projecting through `get_mut` is sound.
+        Pin::new(&mut self.get_mut().wait_for).poll(cx)
+    }
+}
+
+impl fmt::Debug for Delay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Delay").finish()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `wasm32-wasip2` backend for `Delay`, backed by `wasi:clocks/monotonic-clock` and driven by the [`wstd`](https://crates.io/crates/wstd) reactor.

## Motivation

On `wasm32-wasip2` there is no `wasm-bindgen`, so `futures-timer` falls into the `native` backend — which spawns a background timer-wheel thread. The WASI Preview 2 component model is single-threaded, so that thread never runs and the **first poll of any `Delay` aborts at runtime**:

```
thread 'main' panicked at futures-timer-3.0.4/src/native/delay.rs:126:
timer has gone away
```

This makes `futures-timer` unusable on `wasm32-wasip2` today, which in turn breaks every downstream library that relies on it (e.g. several `rust-libp2p` behaviours: ping, kad, gossipsub, request-response, rendezvous, and the Swarm idle-connection timeout). Because `[patch.crates-io]` only applies in the final binary's workspace, downstream libraries cannot fix this for their own users — it has to be fixed here.

## What this does

Adds a third backend selected via `target_env = "p2"` (so `wasm32-wasip1` and any future preview stay on `native`):

| target | backend |
|---|---|
| `wasm32-wasip2` | **new** — `wasi:clocks` + `wstd` reactor |
| `wasm32` + `wasm-bindgen` (non-wasip2) | `wasm` (`setTimeout` via `gloo-timers`) |
| everything else | `native` (thread-based timer wheel) |

The new `Delay` matches the existing API exactly: `new(dur)`, `reset(&mut self, dur)`, `impl Future<Output = ()>`, `impl Debug`.

The `wstd` / `wasip2` dependencies are gated to `cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))`, so they are pulled in **only** for the target where the existing backend is already broken — there is no dependency or behavioural change for any currently-working target.

## Why this is low-risk

The `native` backend already panics at runtime on `wasm32-wasip2`, so this is a pure fix: no working configuration changes. `native` (host) and `wasm32-wasip1` (stays on `native`) are unaffected, and the `wasm-bindgen` browser path is unchanged.

## Testing

- Builds cleanly for `wasm32-wasip2` (new backend), `wasm32-wasip1` (falls through to `native`, no `wstd` pulled in), and the host target (unchanged).
- Verified end-to-end against `rust-libp2p`: a `libp2p-ping` Swarm running as a `wasm32-wasip2` component completes a full ping round-trip (real RTT, no panic) when `futures-timer` is patched to this branch.

## Note for reviewers

`wstd` is the de-facto async reactor for `wasm32-wasip2`; the backend awaits the `wasi:clocks` pollable through it. A fully reactor-agnostic implementation isn't possible because WASI 0.2 has no ambient reactor — each runtime supplies its own. If a target-gated `wstd` dependency is unwelcome, I'm happy to move the backend behind an opt-in `wasip2` feature instead of auto-selecting it. Let me know which you'd prefer.
